### PR TITLE
Update BitCurator Walkthrough.md

### DIFF
--- a/docs/BitCurator Walkthrough/BitCurator Walkthrough.md
+++ b/docs/BitCurator Walkthrough/BitCurator Walkthrough.md
@@ -36,21 +36,21 @@ If you have devices (e.g. USB drives, CD-ROMs) that you'd like to image or explo
 
 The **safe mount script** provides write-blocked access to removable media. **Mounting** is a technical term for registering a storage device with the host system so it can be browsed or used, and you will need to mount any external device attached to the BitCurator system, whether that occurs automatically or by invoking the safe mount script. Images of devices, (e.g. forensic images of floppies, CDs or drives) need to be mounted as well for most uses.
 
-* **[Safely Mount Devices](/documentation/BitCurator Environment/All Step-by-Step Guides/Imaging and Recovery Guides/Safely Mount Devices) (Step-by-Step Guide)**
+* **[Safely Mount Devices](/documentation/All Step-by-Step Guides/Imaging and Recovery Guides/Safely Mount Devices) (Step-by-Step Guide)**
 
 ### Create Disk Images
 
-BitCurator uses open source disk imaging tools, such as [Guymager](/documentation/BitCurator Environment/All Step-by-Step Guides/Imaging and Recovery Guides/Imaging with Guymager) and [dcfldd](https://forensicswiki.xyz/wiki/index.php?title=Dcfldd), to capture bit-identical images from magnetic, optical, solid-state, and hybrid media. Disk images can be captured in various formats, including raw (just the bitstream), E01 (Expert Witness Format, which we support using the open source [libewf](https://forensicswiki.xyz/wiki/index.php?title=Libewf) library), and AFF (Advanced Forensic Format).
+BitCurator uses open source disk imaging tools, such as [Guymager](/documentation/All Step-by-Step Guides/Imaging and Recovery Guides/Imaging with Guymager) and [dcfldd](https://forensicswiki.xyz/wiki/index.php?title=Dcfldd), to capture bit-identical images from magnetic, optical, solid-state, and hybrid media. Disk images can be captured in various formats, including raw (just the bitstream), E01 (Expert Witness Format, which we support using the open source [libewf](https://forensicswiki.xyz/wiki/index.php?title=Libewf) library), and AFF (Advanced Forensic Format).
 
 Capturing disk images in forensic formats such as E01 and AFF provides many advantages. The images can be stored compressed or uncompressed, can be split into multiple storage containers, can be parsed at the file system level without explicitly extracting the raw image, and can be embedded with provenance and capture metadata. **Forensic images ensure that no inadvertent changes are made during pre-ingest chain-of-custody**, and provide a consistent baseline for generating different types of access materials.
 
 In the BitCurator Environment, forensically-packaged disk images can be mounted by right-clicking on them and selecting "Mount Disk Image". This allows you to browse the source in a safe, read-only environment.
 
 * Image with **Guymager:** Create a perfect capture of your device's file structure and all contents (including hidden files and fragments) PLUS package this image with information about the disk imaging process. When anyone accesses the disk image later on, they'll have information about who imaged the device, when the device was imaged, etc. as well as be able to explore the exact state of the device as it was when you imaged it.
-+ **[Imaging with Guymager](/documentation/BitCurator Environment/All Step-by-Step Guides/Imaging and Recovery Guides/Imaging with Guymager) (Step-by-Step Guide)**
++ **[Imaging with Guymager](/documentation/All Step-by-Step Guides/Imaging and Recovery Guides/Imaging with Guymager) (Step-by-Step Guide)**
 * Image with **dcfldd:** This command line program is an enhance version of the **dd** program. If you are having trouble with Guymager, or if you are comfortable with command line use, **dcfldd** can be very useful and scriptable. Please see the [dcfldd entry on the Forensics Wiki](https://forensicswiki.xyz/wiki/index.php?title=Dcfldd) for general use.
 
-Along with **dcfldd**, there are a host of command line tools in the *Imaging and Recovery* folder on the BitCurator Environment desktop, all listed on the **[Tools](/documentation/BitCurator Environment/Tools)** page.
+Along with **dcfldd**, there are a host of command line tools in the *Imaging and Recovery* folder on the BitCurator Environment desktop, all listed on the **[Tools](/documentation/Tools)** page.
 
 Forensics and Reporting
 -----------------------
@@ -61,13 +61,13 @@ BitCurator generates technical metadata in the form of Digital Forensics XML (DF
 
 ### Extract metadata from disk images and files
 
-BitCurator incorporates file system analytics and stream-based forensics technologies to identify and assist with redaction of potentially private and sensitive information (including personally identifiable information). In particular, BitCurator incorporates [fiwalk](/documentation/BitCurator Environment/All Step-by-Step Guides/Forensics and Reporting Guides/Fiwalk), a tool originally developed by Simson Garfinkel (and later incorporated into [The Sleuth Kit](https://www.sleuthkit.org/)), to export an XML file detailing file system hierarchy within a disk image, including files and folders, deleted materials, and information in slack space.
+BitCurator incorporates file system analytics and stream-based forensics technologies to identify and assist with redaction of potentially private and sensitive information (including personally identifiable information). In particular, BitCurator incorporates [fiwalk](/documentation/All Step-by-Step Guides/Forensics and Reporting Guides/Fiwalk), a tool originally developed by Simson Garfinkel (and later incorporated into [The Sleuth Kit](https://www.sleuthkit.org/)), to export an XML file detailing file system hierarchy within a disk image, including files and folders, deleted materials, and information in slack space.
 
 Please see the following **Step-by-Step Guides**: 
 
-* Generate file system metadata as DFXML: [**Fiwalk**](/documentation/BitCurator Environment/All Step-by-Step Guides/Forensics and Reporting Guides/Fiwalk)
-* View, edit, and export metadata from image files: [**pyExifToolGUI**](/documentation/BitCurator Environment/All Step-by-Step Guides/Forensics and Reporting Guides/pyExifToolGUI)
-* View and export information from HFS-formatted disk images: [**HFS Explorer**](/documentation/BitCurator Environment/All Step-by-Step Guides/Forensics and Reporting Guides/HFS Explorer)
+* Generate file system metadata as DFXML: [**Fiwalk**](/documentation/All Step-by-Step Guides/Forensics and Reporting Guides/Fiwalk)
+* View, edit, and export metadata from image files: [**pyExifToolGUI**](/documentation/All Step-by-Step Guides/Forensics and Reporting Guides/pyExifToolGUI)
+* View and export information from HFS-formatted disk images: [**HFS Explorer**](/documentation/All Step-by-Step Guides/Forensics and Reporting Guides/HFS Explorer)
 
 ### Identify potentially private and sensitive information
 
@@ -75,9 +75,9 @@ BitCurator includes bulk\_extractor (and the bulk\_extractor GUI, BEViewer) to a
 
 Please see the following **Step-by-Step Guides**: 
 
-* Find potentially sensitive information: [**Bulk Extractor Viewer**](/documentation/BitCurator Environment/All Step-by-Step Guides/Forensics and Reporting Guides/Bulk Extractor Viewer)
-* Guide to regular expressions in Bulk Extractor: [**Regular Expressions in Bulk Extractor**](/documentation/BitCurator Environment/All Step-by-Step Guides/Forensics and Reporting Guides/Regular Expressions in Bulk Extractor)
-* Guide to Bulk Extractor scanners and what they do: **[Understanding Bulk Extractor Scanners](/documentation/BitCurator Environment/All Step-by-Step Guides/Forensics and Reporting Guides/Understanding Bulk Extractor Scanners)**
+* Find potentially sensitive information: [**Bulk Extractor Viewer**](/documentation/All Step-by-Step Guides/Forensics and Reporting Guides/Bulk Extractor Viewer)
+* Guide to regular expressions in Bulk Extractor: [**Regular Expressions in Bulk Extractor**](/documentation/All Step-by-Step Guides/Forensics and Reporting Guides/Regular Expressions in Bulk Extractor)
+* Guide to Bulk Extractor scanners and what they do: **[Understanding Bulk Extractor Scanners](/documentation/All Step-by-Step Guides/Forensics and Reporting Guides/Understanding Bulk Extractor Scanners)**
 
 ### Generate Forensic Reports
 
@@ -85,20 +85,20 @@ Users can generate human-friendly BitCurator Forensic Reports using the data pro
 
 There are two ways to generate BitCurator Forensic Reports, please reference the following **Step-by-Step Guides**:
 
-***Option A:*** Use "Run All" feature to generate all reports in one step: [**Creating Disk Image Reports using the BitCurator Reporting Tool**](/documentation/BitCurator Environment/All Step-by-Step Guides/Forensics and Reporting Guides/Creating Disk Image Reports using the BitCurator Reporting Tool)***Option B:*** Run each step individually for additional control and customization:
+***Option A:*** Use "Run All" feature to generate all reports in one step: [**Creating Disk Image Reports using the BitCurator Reporting Tool**](/documentation/All Step-by-Step Guides/Forensics and Reporting Guides/Creating Disk Image Reports using the BitCurator Reporting Tool)***Option B:*** Run each step individually for additional control and customization:
 
-1. Find potentially sensitive information: [**Bulk Extractor Viewer**](/documentation/BitCurator Environment/All Step-by-Step Guides/Forensics and Reporting Guides/Bulk Extractor Viewer)
-2. Generate filesystem metadata as DFXML: [**Fiwalk**](/documentation/BitCurator Environment/All Step-by-Step Guides/Forensics and Reporting Guides/Fiwalk)
-3. Generate Annotated Features Reports: [**Annotated Features Report**](/documentation/BitCurator Environment/All Step-by-Step Guides/Forensics and Reporting Guides/Annotated Features Report)
-4. Generate Forensic Reports: **[**Forensic Reports**](/documentation/BitCurator Environment/All Step-by-Step Guides/Forensics and Reporting Guides/Forensic Reports)**
+1. Find potentially sensitive information: [**Bulk Extractor Viewer**](/documentation/All Step-by-Step Guides/Forensics and Reporting Guides/Bulk Extractor Viewer)
+2. Generate filesystem metadata as DFXML: [**Fiwalk**](/documentation/All Step-by-Step Guides/Forensics and Reporting Guides/Fiwalk)
+3. Generate Annotated Features Reports: [**Annotated Features Report**](/documentation/All Step-by-Step Guides/Forensics and Reporting Guides/Annotated Features Report)
+4. Generate Forensic Reports: **[**Forensic Reports**](/documentation/All Step-by-Step Guides/Forensics and Reporting Guides/Forensic Reports)**
 
 ### Deduplicate Files
 
-* Identify and delete duplicate files: [**FSlint**](/documentation/BitCurator Environment/All Step-by-Step Guides/Forensics and Reporting Guides/FSlint) **(Step-by-Step Guide)**
+* Identify and delete duplicate files: [**FSlint**](/documentation/All Step-by-Step Guides/Forensics and Reporting Guides/FSlint) **(Step-by-Step Guide)**
 
 ### File Export
 
-* Access and export files from disk images: [**Access and Export Files from Disk Images**](/documentation/BitCurator Environment/All Step-by-Step Guides/Forensics and Reporting Guides/Access and Export Files from Disk Images) **(Step-by-Step Guide)**
+* Access and export files from disk images: [**Access and Export Files from Disk Images**](/documentation/All Step-by-Step Guides/Forensics and Reporting Guides/Access and Export Files from Disk Images) **(Step-by-Step Guide)**
 
 ### Forensics and Reporting Nautilus Scripts
 
@@ -106,14 +106,14 @@ Nautilus is a popular GUI file manager for Linux and it functions similarly to W
 
 See below for **Step-by-Step Guides** on how to use Nautilus to perform a number of critical data analysis tasks:
 
-* [**Create MD5 Sums (Nautilus)**](/documentation/BitCurator Environment/All Step-by-Step Guides/Forensics and Reporting Guides/Create MD5 Sums (Nautilus))
-* [**Extract Compressed Files (Nautilus)**](/documentation/BitCurator Environment/All Step-by-Step Guides/Forensics and Reporting Guides/Extract Compressed Files (Nautilus))
-* [**Review File Info and Details (Nautilus)**](/documentation/BitCurator Environment/All Step-by-Step Guides/Forensics and Reporting Guides/Review File Info and Details (Nautilus))
-* [**Disk Image Metadata (Nautilus)**](/documentation/BitCurator Environment/All Step-by-Step Guides/Forensics and Reporting Guides/Disk Image Metadata (Nautilus))
-* [**Display a file in Hex editor (Nautilus)**](/documentation/BitCurator Environment/All Step-by-Step Guides/Forensics and Reporting Guides/Display a file in Hex editor (Nautilus))
-* [**Live Search for Files (Nautilus)**](/documentation/BitCurator Environment/All Step-by-Step Guides/Forensics and Reporting Guides/Live Search for Files (Nautilus))
+* [**Create MD5 Sums (Nautilus)**](/documentation/All Step-by-Step Guides/Forensics and Reporting Guides/Create MD5 Sums (Nautilus))
+* [**Extract Compressed Files (Nautilus)**](/documentation/All Step-by-Step Guides/Forensics and Reporting Guides/Extract Compressed Files (Nautilus))
+* [**Review File Info and Details (Nautilus)**](/documentation/All Step-by-Step Guides/Forensics and Reporting Guides/Review File Info and Details (Nautilus))
+* [**Disk Image Metadata (Nautilus)**](/documentation/All Step-by-Step Guides/Forensics and Reporting Guides/Disk Image Metadata (Nautilus))
+* [**Display a file in Hex editor (Nautilus)**](/documentation/All Step-by-Step Guides/Forensics and Reporting Guides/Display a file in Hex editor (Nautilus))
+* [**Live Search for Files (Nautilus)**](/documentation/All Step-by-Step Guides/Forensics and Reporting Guides/Live Search for Files (Nautilus))
 
-BitCurator includes a number of other tools to assist users with data triage; identifying and prioritizing important information in raw and forensically packaged disk images. This includes files format identification, location of deleted files and file fragments, cryptographic hashing, and reporting on potentially private and personally identifying information. BitCurator includes Vassil Roussev's **sdhash** to report on file similarity, **regripper** for Windows registry analysis, and **ClamAV** for virus and malware detection. These are listed on the [Tools](/documentation/BitCurator Environment/Tools) page.
+BitCurator includes a number of other tools to assist users with data triage; identifying and prioritizing important information in raw and forensically packaged disk images. This includes files format identification, location of deleted files and file fragments, cryptographic hashing, and reporting on potentially private and personally identifying information. BitCurator includes Vassil Roussev's **sdhash** to report on file similarity, **regripper** for Windows registry analysis, and **ClamAV** for virus and malware detection. These are listed on the [Tools](/documentation/Tools) page.
 
 Package and Export
 ------------------


### PR DESCRIPTION
removing the string "BitCurator Environment/" from all the URLs to fix the 404 broken links to other parts of the documentation.